### PR TITLE
[DONT MERGE] CI がテスト失敗したことを検出する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  pull_request:
+    branches: [ main, feature/** ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          cache: maven
+      - name: Compile
+        run: mvn --batch-mode clean test-compile
+      - name: Test
+        run: mvn --batch-mode jacoco:prepare-agent test jacoco:report
+      - name: Publish Test Report
+        if: ${{ always() }}
+        uses: mikepenz/action-junit-report@v2
+        with:
+          check_name: 'Test Report'
+          report_paths: '**/surefire-reports/TEST-*.xml'

--- a/src/test/java/lerna/nablarch/batch/parallelizable/handler/NullResultTest.java
+++ b/src/test/java/lerna/nablarch/batch/parallelizable/handler/NullResultTest.java
@@ -12,4 +12,10 @@ public class NullResultTest {
         NullResult instance2 = NullResult.getInstance();
         assertThat(instance1, is(instance2));
     }
+
+    @Test
+    public void ShouldBeFailed() {
+        assertThat(1, is(2));
+    }
+
 }


### PR DESCRIPTION
https://github.com/lerna-stack/nablarch-fw-batch-parallelizable/pull/6 で導入する CI がテスト失敗を検出できることを確認します。
https://github.com/lerna-stack/nablarch-fw-batch-parallelizable/pull/6 がマージできた後、この PR はマージせずにクローズされます。